### PR TITLE
Remove expired cert; make it compile for esp-idf 5.2

### DIFF
--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -133,6 +133,8 @@ component_compile_options (
 	-Wno-missing-braces
 	-Wno-missing-field-initializers
 	-Wno-unused-variable
+	-Wno-format
+	-Wno-array-parameter
 	)
 
 component_compile_definitions (

--- a/port/src/tlsio_esp_tls.c
+++ b/port/src/tlsio_esp_tls.c
@@ -20,6 +20,7 @@
 #include "azure_c_shared_utility/crt_abstractions.h"
 #include "azure_c_shared_utility/tlsio_options.h"
 
+#include "esp_idf_version.h"
 #include "esp_tls.h"
 
 #if CONFIG_ESP_AZURE_USE_SECURE_ELEMENT && (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 0, 0))
@@ -130,7 +131,7 @@ static void internal_close(TLS_IO_INSTANCE* tls_io_instance)
     /* Codes_SRS_TLSIO_30_006: [ The phrase "enter TLSIO_STATE_EXT_CLOSED" means the adapter shall forcibly close any existing connections then call the on_io_close_complete function and pass the on_io_close_complete_context that was supplied in tlsio_close_async. ]*/
     /* Codes_SRS_TLSIO_30_051: [ On success, if the underlying TLS does not support asynchronous closing, then the adapter shall enter TLSIO_STATE_EXT_CLOSED immediately after entering TLSIO_STATE_EX_CLOSING. ]*/
 
-    esp_tls_conn_delete(tls_io_instance->esp_tls_handle);
+    esp_tls_conn_destroy(tls_io_instance->esp_tls_handle);
     while (process_and_destroy_head_message(tls_io_instance, IO_SEND_CANCELLED));
     // singlylinkedlist_destroy gets called in the main destroy
 
@@ -222,7 +223,7 @@ static CONCRETE_IO_HANDLE tlsio_esp_tls_create(void* io_create_parameters)
                 result->pending_transmission_list = NULL;
                 tlsio_options_initialize(&result->options, TLSIO_OPTION_BIT_TRUSTED_CERTS |
                 TLSIO_OPTION_BIT_x509_RSA_CERT | TLSIO_OPTION_BIT_x509_ECC_CERT);
-                result->esp_tls_handle = calloc(1, sizeof(esp_tls_t));
+                result->esp_tls_handle = esp_tls_init();
                 if (result->esp_tls_handle == NULL)
                 {
                     /* Codes_SRS_TLSIO_30_011: [ If any resource allocation fails, tlsio_create shall return NULL. ]*/


### PR DESCRIPTION
* Integrate changes from Floris that weren't yet in master (only in `bace-idf-5.2` branch)
* Remove expired certificate from the list of trusted root certificates